### PR TITLE
Handle VC with one or no type

### DIFF
--- a/mock-user-management.js
+++ b/mock-user-management.js
@@ -127,8 +127,9 @@ function getCredentialId(vp) {
 }
 
 function getCredentialType(vc) {
-  const types = vc.type;
-  return types.slice(1).join('/');
+  if (!vc) return 'Credential';
+  const types = Array.isArray(vc.type) ? vc.type : [vc.type];
+  return types.length > 1 ? types.slice(1).join('/') : types[0];
 }
 
 /**

--- a/mock-user-management.js
+++ b/mock-user-management.js
@@ -127,7 +127,9 @@ function getCredentialId(vp) {
 }
 
 function getCredentialType(vc) {
-  if (!vc) return 'Credential';
+  if(!vc) {
+    return 'Credential'
+  };
   const types = Array.isArray(vc.type) ? vc.type : [vc.type];
   return types.length > 1 ? types.slice(1).join('/') : types[0];
 }
@@ -149,5 +151,4 @@ function resetCurrentUser() {
   console.log('Clearing login cookie.');
   Cookies.remove('username', {path: ''});
 }
-
 


### PR DESCRIPTION
Currently if the credential `type` is not an Array, an error is thrown which breaks the app:
```
Uncaught (in promise) TypeError: types.slice(...).join is not a function
    getCredentialType https://chapi-demo-wallet.digitalbazaar.com/mock-user-management.js:131
    handleStoreEvent https://chapi-demo-wallet.digitalbazaar.com/wallet-ui-store.html:95
```
This PR updates the `getCredentialType` function to do more checking of the `type` property, including to allow use of credentials with a single type value (`"VerifiableCredential"`). In the case of a single-type credential it now returns the base type rather than the empty string.